### PR TITLE
Switch from `.env` to `const`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,80 +1,38 @@
-//! Generates the environment '.env' and 'src/wrapper.h'
+//! Provides the directory locations as environment variables for the library.
 //!
 //! SPDX-FileCopyrightText: HighTec EDV-Systeme GmbH
-//! 
+//!
 //! SPDX-License-Identifier: Apache-2.0
-//! 
-use std::env;
+//!
 use std::path::PathBuf;
-use std::io::Write;
-use std::ffi::OsString;
-use std::fs::read_dir;
-use std::io::ErrorKind;
-
 
 fn main() {
-
- for (n,v) in std::env::vars() {
-        println!("{}: {}", n,v);
-    }
-
     let src = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
-    let pxroot = src.join("tricore/v8.2.1.eval/kernel");
-    let incl = pxroot.join("include");
-    let pxutil = src.join("tricore/v8.2.1.eval/utilities");
-    let pxuincl = pxutil.join("include");
+    let px_root = src.join("tricore/v8.2.1.eval/kernel");
+    let px_root_incl = px_root.join("include");
+    let px_utils = src.join("tricore/v8.2.1.eval/utilities");
+    let px_utils_incl = px_utils.join("include");
+    let api_src = src.join("api-src");
 
+    println!(
+        "cargo:rustc-env=TRI_8_2_1_EVAL_KERNEL={}",
+        px_root.to_str().unwrap()
+    );
+    println!(
+        "cargo:rustc-env=TRI_8_2_1_EVAL_KERNEL_INCL={}",
+        px_root_incl.to_str().unwrap()
+    );
+    println!(
+        "cargo:rustc-env=TRI_8_2_1_EVAL_UTILS={}",
+        px_utils.to_str().unwrap()
+    );
+    println!(
+        "cargo:rustc-env=TRI_8_2_1_EVAL_UTILS_INCL={}",
+        px_utils_incl.to_str().unwrap()
+    );
+    println!(
+        "cargo:rustc-env=TRI_8_2_1_EVAL_API_SRC={}",
+        api_src.to_str().unwrap()
+    );
     println!("cargo:rerun-if-changed=build.rs");
-
-    match  env::current_exe() {
-        Ok(p) => println!("EXE-DIR={:?}", p),
-        Err(e) => println!("Error {:?}", e)
-    }
-    match  env::current_dir() {
-        Ok(p) => println!("RUN-DIR={:?}", p),
-        Err(e) => println!("Error {:?}", e)
-    }
-    let wrapper = src.join("src/wrapper.h");
-    let mut w = std::fs::File::create(wrapper).expect("Couldn't create wrapper.h");
-    writeln!(&mut w, "#define __TC162__").expect("write to wrapper.h failed");
-    writeln!(&mut w, "#include \"{}/pxdef.h\"", incl.to_str().unwrap()).expect("write to wrapper.h failed");
-    writeln!(&mut w, "#include \"{}/pxname.h\"", pxuincl.to_str().unwrap()).expect("write to wrapper.h failed");
-    writeln!(&mut w, "#include \"{}/pxhndcall.h\"", pxuincl.to_str().unwrap()).expect("write to wrapper.h failed");
-    writeln!(&mut w, "#include \"{}/pxinfo.h\"", incl.to_str().unwrap()).expect("write to wrapper.h failed");
-    _ = w.flush();
-
-    let root = get_project_root().expect("No Project Root found");
-    let envfile = root.join(".env");
-    let mut file = std::fs::File::create(envfile).expect("Couldn't create some.txt");
-    writeln!(&mut file, "export PXROS_ROOT_PATH={}", pxroot.to_str().unwrap()).expect("write to .env failed");
-    writeln!(&mut file, "export PXROS_UTILS={}", pxutil.to_str().unwrap()).expect("write to .env failed");
-    _ = file.flush();
-
-}
-
-
-/// Get the project root (relative to closest Cargo.lock file)
-/// ```rust
-/// match get_project_root() {
-///     Ok(p) => println!("Current project root is {:?}", p),
-///     Err(e) => println!("Error obtaining project root {:?}", e)
-/// };
-/// ```
-pub fn get_project_root() -> std::io::Result<PathBuf> {
-    let exe = env::current_exe()?;
-    let path = exe.as_path().parent().unwrap();
-    let mut path_ancestors = path.ancestors();
-
-
-    while let Some(p) = path_ancestors.next() {
-        println!("DIR: {}", p.to_str().unwrap());
-        let has_cargo =
-            read_dir(p)?
-                .into_iter()
-                .any(|p| p.unwrap().file_name() == OsString::from("Cargo.toml"));
-        if has_cargo {
-            return Ok(PathBuf::from(p))
-        }
-    }
-    Err(std::io::Error::new(ErrorKind::NotFound, "Ran out of places to find Cargo.toml"))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,24 @@
 //!
 //! SPDX-FileCopyrightText: HighTec EDV-Systeme GmbH
-//! 
+//!
 //! SPDX-License-Identifier: Apache-2.0
-//! 
-use std::include_str;
+//!
 
-// Provide wrapper header for the use by other crates
-// wrapper.h will use absolute paths to the API header
-pub const WRAPPER: &'static str = include_str!("wrapper.h");
+/// PXROS v8.2.1.eval header.h contents.
+pub const TRI_8_2_1_EVAL_WRAPPER: &str = "#define __TC162__\n\
+    #include \"pxdef.h\"\n\
+    #include \"pxname.h\"\n\
+    #include \"pxhndcall.h\"\n\
+    #include \"pxinfo.h\"\n
+    ";
+
+/// PXROS v8.2.1.eval root/kernel directory.
+pub const TRI_8_2_1_EVAL_KERNEL: &str = env!("TRI_8_2_1_EVAL_KERNEL");
+/// PXROS v8.2.1.eval root/kernel includes directory.
+pub const TRI_8_2_1_EVAL_KERNEL_INCL: &str = env!("TRI_8_2_1_EVAL_KERNEL_INCL");
+/// PXROS v8.2.1.eval utils directory.
+pub const TRI_8_2_1_EVAL_UTILS: &str = env!("TRI_8_2_1_EVAL_UTILS");
+/// PXROS v8.2.1.eval utils include directory.
+pub const TRI_8_2_1_EVAL_UTILS_INCL: &str = env!("TRI_8_2_1_EVAL_UTILS_INCL");
+/// PXROS v8.2.1.eval API documentation directory.
+pub const TRI_8_2_1_EVAL_API_SRC: &str = env!("TRI_8_2_1_EVAL_API_SRC");

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -1,5 +1,0 @@
-#define __TC162__
-#include "pxdef.h"
-#include "pxname.h"
-#include "pxhndcall.h"
-#include "pxinfo.h"


### PR DESCRIPTION
While the current solution works, I think using `const` could make versioning in the future easier and also makes integrating this into down-stream crates simpler. This also removes a lot of logic which should make maintaining this easier in the future.

The current solution also breaks the "rule" that build scripts should not modify anything but the contents of the `OUT_DIR` directory (https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script).

This also makes the `api-src` folder available down-stream.

I'll also create a PR to match the changes in the `pxros` crate.